### PR TITLE
[SOA-024][Enhancement] Separate the "ApiControllers" from the "ApiHost" (eShopOnlineApiRestful)

### DIFF
--- a/Implementations/eShopOnlineApiRestful/Abstracts/AbstractApiController.cs
+++ b/Implementations/eShopOnlineApiRestful/Abstracts/AbstractApiController.cs
@@ -1,0 +1,16 @@
+﻿using Contracts.Business.Managers;
+
+namespace eShopOnlineApiRestful.Abstracts
+{
+    [ApiController]
+    [Route("api")]
+    public abstract class AbstractApiController : ControllerBase
+    {
+        protected readonly IServiceManager _services;
+
+        protected AbstractApiController(ControllerParams controllerParams)
+        {
+            _services = controllerParams.Service;
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Abstracts/AbstractController.cs
+++ b/Implementations/eShopOnlineApiRestful/Abstracts/AbstractController.cs
@@ -1,0 +1,14 @@
+﻿using Contracts.Business.Managers;
+
+namespace eShopOnlineApiRestful.Abstracts
+{
+    public abstract class AbstractController : ControllerBase
+    {
+        protected readonly IServiceManager _services;
+
+        protected AbstractController(ControllerParams controllerParams)
+        {
+            _services = controllerParams.Service;
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/AssemblyReference.cs
+++ b/Implementations/eShopOnlineApiRestful/AssemblyReference.cs
@@ -1,0 +1,6 @@
+﻿namespace eShopOnlineApiRestful
+{
+    public static class AssemblyReference
+    {
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Controllers/CompanyController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/CompanyController.cs
@@ -1,0 +1,9 @@
+﻿namespace eShopOnlineApiRestful.Controllers
+{
+    public sealed class CompanyController : AbstractApiController
+    {
+        public CompanyController(ControllerParams controllerParams) : base(controllerParams)
+        {
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Controllers/CustomerController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/CustomerController.cs
@@ -1,0 +1,28 @@
+﻿using Shared.DTOs.Outputs.EntityDtos;
+
+namespace eShopOnlineApiRestful.Controllers
+{
+    public sealed class CustomerController : AbstractApiController
+    {
+        public CustomerController(ControllerParams controllerParams) : base(controllerParams)
+        {
+        }
+
+        [HttpGet]
+        [Route("customers")]
+        public IActionResult GetAll()
+        {
+            IEnumerable<EmployeeDto> employeeDto = _services.Employee.GetAll(isTrackChanges: false);
+            return Ok(employeeDto);
+        }
+
+        [HttpGet]
+        [Route("customers/{id:guid}")]
+        public IActionResult GetById(Guid id)
+        {
+            EmployeeDto? employeeDto = _services.Employee.GetById(isTrackChanges: false, id);
+            return Ok(employeeDto);
+        }
+
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Controllers/EmployeeController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/EmployeeController.cs
@@ -1,0 +1,9 @@
+﻿namespace eShopOnlineApiRestful.Controllers
+{
+    public sealed class EmployeeController : AbstractApiController
+    {
+        public EmployeeController(ControllerParams controllerParams) : base(controllerParams)
+        {
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Controllers/ProductController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/ProductController.cs
@@ -1,0 +1,9 @@
+﻿namespace eShopOnlineApiRestful.Controllers
+{
+    public sealed class ProductController : AbstractApiController
+    {
+        public ProductController(ControllerParams controllerParams) : base(controllerParams)
+        {
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Controllers/StoreController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/StoreController.cs
@@ -1,0 +1,9 @@
+﻿namespace eShopOnlineApiRestful.Controllers
+{
+    public sealed class StoreController : AbstractApiController
+    {
+        public StoreController(ControllerParams controllerParams) : base(controllerParams)
+        {
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Parameters/ControllerParams.cs
+++ b/Implementations/eShopOnlineApiRestful/Parameters/ControllerParams.cs
@@ -1,0 +1,14 @@
+﻿using Contracts.Business.Managers;
+
+namespace eShopOnlineApiRestful.Parameters
+{
+    public sealed class ControllerParams
+    {
+        public readonly IServiceManager Service;
+
+        public ControllerParams(IServiceManager service) 
+        {
+            Service = service;
+        }
+    }
+}

--- a/Implementations/eShopOnlineApiRestful/Using.cs
+++ b/Implementations/eShopOnlineApiRestful/Using.cs
@@ -1,0 +1,3 @@
+﻿global using eShopOnlineApiRestful.Abstracts;
+global using eShopOnlineApiRestful.Parameters;
+global using Microsoft.AspNetCore.Mvc;

--- a/Implementations/eShopOnlineApiRestful/eShopOnlineApiRestful.csproj
+++ b/Implementations/eShopOnlineApiRestful/eShopOnlineApiRestful.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Cores\Contracts.Business\Contracts.Business.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/eShopOnlineApiHost/Extensions/DIRegisterExtensions.cs
+++ b/eShopOnlineApiHost/Extensions/DIRegisterExtensions.cs
@@ -1,0 +1,50 @@
+﻿using Contracts.Business.Managers;
+using Contracts.Repositories.Managers;
+using Contracts.Utilities.Mapper;
+using eShopOnlineBusiness.Managers;
+using eShopOnlineBusiness.Parameters;
+using eShopOnlineEFCore.Context;
+using eShopOnlineRepositories.Managers;
+using eShopOnlineRepositories.Parameters;
+using eShopOnlineUtilities.AutoMapper;
+using eShopOnlineUtilities.AutoMapper.Profiles;
+using Microsoft.EntityFrameworkCore;
+
+namespace eShopOnlineApiHost.Extensions
+{
+    public static class DIRegisterExtensions
+    {
+        public static void DIRegister_ShopOnlineContext(this IServiceCollection services, IConfiguration configuration)
+        {
+            string? connectionStrings = configuration.GetConnectionString("eShopOnlineConnection");
+            if (connectionStrings != null)
+            {
+                services.AddDbContext<ShopOnlineContext>(
+                    options => options.UseSqlServer(connectionStrings)
+                );
+            }
+            else
+            {
+                throw new Exception("ConnectionStrings is missing");
+            }
+        }
+
+        public static void DIRegister_Repositories(this IServiceCollection services)
+        {
+            services.AddScoped<RepositoryParams>();
+            services.AddScoped<IRepositoryManager, RepositoryManager>();
+        }
+
+        public static void DIRegister_Business(this IServiceCollection services)
+        {
+            services.AddScoped<ServiceParams>();
+            services.AddScoped<IServiceManager, ServiceManager>();
+        }
+
+        public static void DIRegister_AutoMapper(this IServiceCollection services)
+        {
+            services.AddAutoMapper(typeof(MappingProfiles));
+            services.AddScoped<IMapperService, AutoMapperService>();
+        }
+    }
+}

--- a/eShopOnlineApiHost/Program.cs
+++ b/eShopOnlineApiHost/Program.cs
@@ -1,7 +1,10 @@
 using Contracts.Business.Managers;
+using Contracts.Repositories.Managers;
 using Contracts.Utilities.Mapper;
+using eShopOnlineApiHost.Extensions;
 using eShopOnlineBusiness.Managers;
 using eShopOnlineEFCore.Context;
+using eShopOnlineRepositories.Managers;
 using eShopOnlineUtilities.AutoMapper;
 using eShopOnlineUtilities.AutoMapper.Profiles;
 using Microsoft.EntityFrameworkCore;
@@ -15,15 +18,15 @@ namespace eShopOnlineApiHost
             var builder = WebApplication.CreateBuilder(args);
 
             // Add services to the container.
-            builder.Services.AddDbContext<ShopOnlineContext>(
-                options => options.UseSqlServer(builder.Configuration.GetConnectionString("eShopOnlineConnection"))
-            );
+            builder.Services.AddControllers()
+                .AddApplicationPart(typeof(eShopOnlineApiRestful.AssemblyReference).Assembly);
 
-            builder.Services.AddControllers();
-            builder.Services.AddAutoMapper(typeof(MappingProfiles));
-            builder.Services.AddScoped<IMapperService, AutoMapperService>();
-            builder.Services.AddScoped<IServiceManager, ServiceManager>();
-            
+            // My DIRegister
+            builder.Services.DIRegister_ShopOnlineContext(builder.Configuration);
+            builder.Services.DIRegister_Repositories();
+            builder.Services.DIRegister_Business();
+            builder.Services.DIRegister_AutoMapper();
+
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/eShopOnlineApiHost/eShopOnlineApiHost.csproj
+++ b/eShopOnlineApiHost/eShopOnlineApiHost.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Implementations\eShopOnlineApiRestful\eShopOnlineApiRestful.csproj" />
     <ProjectReference Include="..\Implementations\eShopOnlineBusiness\eShopOnlineBusiness.csproj" />
     <ProjectReference Include="..\Implementations\eShopOnlineRepositories\eShopOnlineRepositories.csproj" />
     <ProjectReference Include="..\Implementations\eShopOnlineUtilities\eShopOnlineUtilities.csproj" />

--- a/eShopOnlineApiHost/eShopOnlineApiHost.sln
+++ b/eShopOnlineApiHost/eShopOnlineApiHost.sln
@@ -25,9 +25,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contracts", "..\Cores\Contr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "eShopOnlineUtilities", "..\Implementations\eShopOnlineUtilities\eShopOnlineUtilities.csproj", "{8C3BD090-3AC3-4A10-AF6C-81B2E2788361}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopOnlineBusiness", "..\Implementations\eShopOnlineBusiness\eShopOnlineBusiness.csproj", "{20B6C851-809F-4044-90F4-3581A34CA991}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "eShopOnlineBusiness", "..\Implementations\eShopOnlineBusiness\eShopOnlineBusiness.csproj", "{20B6C851-809F-4044-90F4-3581A34CA991}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contracts.Business", "..\Cores\Contracts.Business\Contracts.Business.csproj", "{CF6E3325-5BEC-4B1A-9B13-A134B4301C13}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Contracts.Business", "..\Cores\Contracts.Business\Contracts.Business.csproj", "{CF6E3325-5BEC-4B1A-9B13-A134B4301C13}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "eShopOnlineApiRestful", "..\Implementations\eShopOnlineApiRestful\eShopOnlineApiRestful.csproj", "{016B77C7-BC66-417B-BE48-426340472CCD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,6 +77,10 @@ Global
 		{CF6E3325-5BEC-4B1A-9B13-A134B4301C13}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF6E3325-5BEC-4B1A-9B13-A134B4301C13}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF6E3325-5BEC-4B1A-9B13-A134B4301C13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{016B77C7-BC66-417B-BE48-426340472CCD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{016B77C7-BC66-417B-BE48-426340472CCD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{016B77C7-BC66-417B-BE48-426340472CCD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{016B77C7-BC66-417B-BE48-426340472CCD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +96,7 @@ Global
 		{8C3BD090-3AC3-4A10-AF6C-81B2E2788361} = {D510F032-6744-44B6-9209-41EB96626B53}
 		{20B6C851-809F-4044-90F4-3581A34CA991} = {D510F032-6744-44B6-9209-41EB96626B53}
 		{CF6E3325-5BEC-4B1A-9B13-A134B4301C13} = {1E781C52-0C3E-42B2-ABBC-1D2B18453F0D}
+		{016B77C7-BC66-417B-BE48-426340472CCD} = {D510F032-6744-44B6-9209-41EB96626B53}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9D826026-5075-4DF3-8BAA-CD2C38819842}


### PR DESCRIPTION
#### =====AFTER=====
**1) Describe the solutions**
- I will create a separate module used for the Controllers (eShopOnlineApiRestful)
- I need an AssemblyReference file to connect to ServiceCollection in ApiHost (eShopOnlineApiHost)

**2) Pros and Cons of this solution**
- **Pros**: 
- The 2 modules are **`separate in the responsibilities`**. 
  + `Host` - responsible for `registering DI`.
  + `ApiRestful` - is used as the `Controller component`.
- `eShopOnlineApiRestful` **`ONLY`** can `use the ESSENTIAL reference modules.`

**3) Are there any NEW (technical, code,...) ?**
- `eShopOnlineApiRestful` needs to install the package: **Microsoft.AspNetCore.Mvc.Core**

**4) Is it challenging and difficult to do? Why?**
- Not difficult. It's a new approach way.

**5) Any other notes?**
- I can register **`DI for A Single Class`**: `services.AddScoped<RepositoryParams>();`