### PR TITLE
[SOA-038][Fixbug] RE-Config NLog library in the project + RE-Use ILogger<T> interface (Controller layer).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 *.user
 *.userosscache
 *.sln.docstates
+LogsDev/
+LogsProd/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/Implementations/eShopOnlineApiRestful/Abstracts/AbstractApiController.cs
+++ b/Implementations/eShopOnlineApiRestful/Abstracts/AbstractApiController.cs
@@ -5,15 +5,19 @@ namespace eShopOnlineApiRestful.Abstracts
 {
     [ApiController]
     [Route("api")]
-    public abstract class AbstractApiController : ControllerBase
+    public abstract class AbstractApiController<TDerivedController> : ControllerBase
     {
+        protected readonly ILogger<TDerivedController> _logger;
+
         //private readonly ILogService _logService;
         protected readonly IServiceManager _services;
         protected abstract string ClassName { get; }
 
-        protected AbstractApiController(ControllerParams controllerParams)
+        protected AbstractApiController(ILogger<TDerivedController> logger, 
+                                        ControllerParams controllerParams)
         {
             //_logService = controllerParams.LogService;
+            _logger = logger;
             _services = controllerParams.ServiceManager;
         }
 

--- a/Implementations/eShopOnlineApiRestful/Controllers/CompanyController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/CompanyController.cs
@@ -1,10 +1,12 @@
 ﻿namespace eShopOnlineApiRestful.Controllers
 {
-    public sealed class CompanyController : AbstractApiController
+    public sealed class CompanyController : AbstractApiController<CompanyController>
     {
         protected override string ClassName => nameof(CompanyController);
 
-        public CompanyController(ControllerParams controllerParams) : base(controllerParams)
+        public CompanyController(ILogger<CompanyController> logger, 
+                                 ControllerParams controllerParams) 
+            : base(logger, controllerParams)
         {
         }
 
@@ -12,6 +14,7 @@
         [Route("companies", Name = "GetAllCompanies")]
         public IActionResult GetAllCompanies()
         {
+            _logger.LogInformation("ax");
             LogRequestInfo();
 
             LogMethodInfo(nameof(GetAllCompanies));

--- a/Implementations/eShopOnlineApiRestful/Controllers/CustomerController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/CustomerController.cs
@@ -1,10 +1,12 @@
 ﻿namespace eShopOnlineApiRestful.Controllers
 {
-    public sealed class CustomerController : AbstractApiController
+    public sealed class CustomerController : AbstractApiController<CustomerController>
     {
         protected override string ClassName => nameof(CustomerController);
 
-        public CustomerController(ControllerParams controllerParams) : base(controllerParams)
+        public CustomerController(ILogger<CustomerController> logger, 
+                                  ControllerParams controllerParams) 
+            : base(logger, controllerParams)
         {
         }
 

--- a/Implementations/eShopOnlineApiRestful/Controllers/EmployeeController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/EmployeeController.cs
@@ -1,10 +1,12 @@
 ﻿namespace eShopOnlineApiRestful.Controllers
 {
-    public sealed class EmployeeController : AbstractApiController
+    public sealed class EmployeeController : AbstractApiController<EmployeeController>
     {
         protected override string ClassName => nameof(EmployeeController);
 
-        public EmployeeController(ControllerParams controllerParams) : base(controllerParams)
+        public EmployeeController(ILogger<EmployeeController> logger, 
+                                  ControllerParams controllerParams) 
+            : base(logger, controllerParams)
         {
         }
 

--- a/Implementations/eShopOnlineApiRestful/Controllers/ProductController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/ProductController.cs
@@ -1,10 +1,12 @@
 ﻿namespace eShopOnlineApiRestful.Controllers
 {
-    public sealed class ProductController : AbstractApiController
+    public sealed class ProductController : AbstractApiController<ProductController>
     {
         protected override string ClassName => nameof(ProductController);
 
-        public ProductController(ControllerParams controllerParams) : base(controllerParams)
+        public ProductController(ILogger<ProductController> logger,
+                                 ControllerParams controllerParams) 
+            : base(logger, controllerParams)
         {
         }
 

--- a/Implementations/eShopOnlineApiRestful/Controllers/StoreController.cs
+++ b/Implementations/eShopOnlineApiRestful/Controllers/StoreController.cs
@@ -1,10 +1,12 @@
 ﻿namespace eShopOnlineApiRestful.Controllers
 {
-    public sealed class StoreController : AbstractApiController
+    public sealed class StoreController : AbstractApiController<StoreController>
     {
         protected override string ClassName => nameof(StoreController);
 
-        public StoreController(ControllerParams controllerParams) : base(controllerParams)
+        public StoreController(ILogger<StoreController> logger, 
+                               ControllerParams controllerParams) 
+            : base(logger, controllerParams)
         {
         }
 

--- a/Implementations/eShopOnlineApiRestful/Using.cs
+++ b/Implementations/eShopOnlineApiRestful/Using.cs
@@ -1,8 +1,7 @@
-﻿global using Contracts.Utilities.Logger;
-global using eShopOnlineApiRestful.Abstracts;
+﻿global using eShopOnlineApiRestful.Abstracts;
 global using eShopOnlineApiRestful.Parameters;
-global using Microsoft.AspNetCore.Http;
 global using Microsoft.AspNetCore.Mvc;
+global using Microsoft.Extensions.Logging;
 global using Shared.DTOs.Inputs.FromBody.CreationDtos;
 global using Shared.DTOs.Inputs.FromBody.UpdateDtos;
 global using Shared.DTOs.Outputs.EntityDtos;

--- a/Implementations/eShopOnlineApiRestful/eShopOnlineApiRestful.csproj
+++ b/Implementations/eShopOnlineApiRestful/eShopOnlineApiRestful.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Implementations/eShopOnlineUtilities/NLog/nlog.Development.config
+++ b/Implementations/eShopOnlineUtilities/NLog/nlog.Development.config
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      internalLogLevel="Info"
+      internalLogFile=".\LogsDev\Internal\internal-nlog.txt">
+
+	<!-- enable asp.net core layout renderers -->
+	<extensions>
+		<add assembly="NLog.Web.AspNetCore"/>
+	</extensions>
+	
+	<!-- the targets to write to -->
+	<targets>
+		<!-- [FILE] Target for all log messages with basic details -->
+		<target xsi:type="File" 
+				name="systemLogs" 
+				fileName="..\..\..\LogsDev\System\${shortdate}_system.txt"
+				layout="${longdate}|${event-properties:item=EventId:whenEmpty=0}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}" />
+
+		<!-- [FILE] Target for own log messages with extra web details using some ASP.NET core renderers -->
+		<target xsi:type="File" 
+				name="apiLogs" 
+				fileName="..\..\..\LogsDev\Api\${shortdate}_api.txt"
+				layout="${longdate}|${event-properties:item=EventId:whenEmpty=0}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}" />
+
+		<!-- [CONSOLE] Target for hosting lifetime messages to improve Docker / Visual Studio startup detection -->
+		<target xsi:type="Console" 
+				name="lifetimeConsole" 
+				layout="${MicrosoftConsoleLayout}" />
+	</targets>
+
+	<!-- rules to map from logger name to target -->
+	<rules>
+		<!--ALL LOGS -->
+		<logger name="*" 
+				minlevel="Trace" 
+				writeTo="systemLogs" />
+
+		<!--Output hosting lifetime messages to console target for faster startup detection -->
+		<logger name="Microsoft.Hosting.Lifetime" 
+				minlevel="Info" 
+				writeTo="lifetimeConsole" 
+				final="true" />
+
+		<!--API LOGS - just essential messages-->
+
+		<!--CONTENTS: Executed DbCommand (time) , Opening connection , Closing connection-->
+		<logger name="Microsoft.EntityFrameworkCore.Database.*" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: 'ShopOnlineContext' disposed -->
+		<logger name="Microsoft.EntityFrameworkCore.Infrastructure" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Compiling query , Generated query -->
+		<logger name="Microsoft.EntityFrameworkCore.Query" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Validation state , Executed action (time) -->
+		<logger name="Microsoft.AspNetCore.Mvc.Infrastructure.*" minlevel="Info" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Request starting (time) , Request finished (time) -->
+		<logger name="Microsoft.AspNetCore.Hosting.Diagnostics" minlevel="Info" writeTo="apiLogs" final="true" />
+		
+		<!--CONTENTS: All hosts are allowed -->
+		<logger name="Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware" minlevel="Trace" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Request matched endpoint , Request did not match any endpoints -->
+		<logger name="Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware" minlevel="Debug" writeTo="apiLogs" final="true" />
+		
+		<!--CONTENTS: Executed endpoint-->
+		<logger name="Microsoft.AspNetCore.Routing.EndpointMiddleware" minlevel="Info" writeTo="apiLogs" final="true" />
+
+		<logger name="eShopOnline*" minlevel="Trace" writeTo="apiLogs" final="true" />
+
+		<logger name="*" minlevel="Info" writeTo="apiLogs" final="true" />
+		
+	</rules>
+</nlog>

--- a/Implementations/eShopOnlineUtilities/NLog/nlog.Production.config
+++ b/Implementations/eShopOnlineUtilities/NLog/nlog.Production.config
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      autoReload="true"
+      internalLogLevel="Info"
+      internalLogFile=".\LogsProd\Internal\internal-nlog.txt">
+
+	<!-- enable asp.net core layout renderers -->
+	<extensions>
+		<add assembly="NLog.Web.AspNetCore"/>
+	</extensions>
+
+	<!-- the targets to write to -->
+	<targets>
+		<!-- [FILE] Target for all log messages with basic details -->
+		<target xsi:type="File"
+				name="systemLogs"
+				fileName="..\..\..\LogsProd\System\${shortdate}_system.txt"
+				layout="${longdate}|${event-properties:item=EventId:whenEmpty=0}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}" />
+
+		<!-- [FILE] Target for own log messages with extra web details using some ASP.NET core renderers -->
+		<target xsi:type="File"
+				name="apiLogs"
+				fileName="..\..\..\LogsProd\Api\${shortdate}_api.txt"
+				layout="${longdate}|${event-properties:item=EventId:whenEmpty=0}|${level:uppercase=true}|${logger}|${message} ${exception:format=tostring}" />
+
+		<!-- [CONSOLE] Target for hosting lifetime messages to improve Docker / Visual Studio startup detection -->
+		<target xsi:type="Console"
+				name="lifetimeConsole"
+				layout="${MicrosoftConsoleLayout}" />
+	</targets>
+
+	<!-- rules to map from logger name to target -->
+	<rules>
+		<!--ALL LOGS -->
+		<logger name="*"
+				minlevel="Trace"
+				writeTo="systemLogs" />
+
+		<!--Output hosting lifetime messages to console target for faster startup detection -->
+		<logger name="Microsoft.Hosting.Lifetime"
+				minlevel="Info"
+				writeTo="lifetimeConsole"
+				final="true" />
+
+		<!--API LOGS - just essential messages-->
+
+		<!--CONTENTS: Executed DbCommand (time) , Opening connection , Closing connection-->
+		<logger name="Microsoft.EntityFrameworkCore.Database.*" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: 'ShopOnlineContext' disposed -->
+		<logger name="Microsoft.EntityFrameworkCore.Infrastructure" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Compiling query , Generated query -->
+		<logger name="Microsoft.EntityFrameworkCore.Query" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Validation state , Executed action (time) -->
+		<logger name="Microsoft.AspNetCore.Mvc.Infrastructure.*" minlevel="Info" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Request starting (time) , Request finished (time) -->
+		<logger name="Microsoft.AspNetCore.Hosting.Diagnostics" minlevel="Info" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: All hosts are allowed -->
+		<logger name="Microsoft.AspNetCore.HostFiltering.HostFilteringMiddleware" minlevel="Trace" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Request matched endpoint , Request did not match any endpoints -->
+		<logger name="Microsoft.AspNetCore.Routing.EndpointRoutingMiddleware" minlevel="Debug" writeTo="apiLogs" final="true" />
+
+		<!--CONTENTS: Executed endpoint-->
+		<logger name="Microsoft.AspNetCore.Routing.EndpointMiddleware" minlevel="Info" writeTo="apiLogs" final="true" />
+
+		<logger name="eShopOnline*" minlevel="Info" writeTo="apiLogs" final="true" />
+
+		<logger name="*" minlevel="Info" writeTo="apiLogs" final="true" />
+
+	</rules>
+</nlog>

--- a/Implementations/eShopOnlineUtilities/eShopOnlineUtilities.csproj
+++ b/Implementations/eShopOnlineUtilities/eShopOnlineUtilities.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="NLog" Version="5.2.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.2" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eShopOnlineApiHost/Constants/SystemVariables.cs
+++ b/eShopOnlineApiHost/Constants/SystemVariables.cs
@@ -3,7 +3,10 @@
     public static class SystemVariables
     {
         public static readonly string EShopConnectionString = "eShopOnlineConnection";
-        public static readonly string PathEShopSolution = Directory.GetCurrentDirectory().Replace("eShopOnlineApiHost", "");
-        public static readonly string PathNLogConfigFile = String.Concat(PathEShopSolution, "Implementations\\eShopOnlineUtilities\\NLog\\NLog.config");
+        public static readonly string SolutionEShopOnlineApiPath = Directory.GetCurrentDirectory().Replace("eShopOnlineApiHost", "");
+        public static readonly string PathNLogConfigFile = String.Concat(SolutionEShopOnlineApiPath, "Implementations\\eShopOnlineUtilities\\NLog\\NLog.config");
+
+        public static readonly string NLogConfigFilePath = String.Concat(SolutionEShopOnlineApiPath, $".\\Implementations\\eShopOnlineUtilities\\NLog\\nlog.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.config");
+
     }
 }

--- a/eShopOnlineApiHost/Program.cs
+++ b/eShopOnlineApiHost/Program.cs
@@ -1,5 +1,6 @@
-using eShopOnlineApiHost.Extensions;
 using eShopOnlineApiRestful.Parameters;
+using NLog;
+using NLog.Web;
 
 namespace eShopOnlineApiHost
 {
@@ -7,41 +8,67 @@ namespace eShopOnlineApiHost
     {
         public static void Main(string[] args)
         {
-            var builder = WebApplication.CreateBuilder(args);
+            // Early init of NLog to allow startup and exception logging, before host is built
+            var logger = LogManager.Setup()
+                            .LoadConfigurationFromFile(
+                                optional: true,
+                                candidateFilePaths: new List<string> { SystemVariables.NLogConfigFilePath })
+                            .GetCurrentClassLogger();
+            logger.Info("INIT main");
 
-            // Add services to the container.
-            builder.Services.AddScoped<ControllerParams>();
-            builder.Services.AddControllers()
-                .AddApplicationPart(typeof(eShopOnlineApiRestful.AssemblyReference).Assembly);
-
-            // My DIRegister
-            builder.Services.DIRegister_ShopOnlineContext(builder.Configuration);
-            builder.Services.DIRegister_Repositories();
-            builder.Services.DIRegister_Business();
-            builder.Services.DIRegister_NLog();
-            builder.Services.DIRegister_AutoMapper();
-
-            // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-            builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
-
-            var app = builder.Build();
-
-            // Configure the HTTP request pipeline.
-            if (app.Environment.IsDevelopment())
+            try
             {
-                app.UseSwagger();
-                app.UseSwaggerUI();
+                var builder = WebApplication.CreateBuilder(args);   // Include configuring 4 default LogProviders
+
+                // Add services to the container.
+                builder.Services.AddScoped<ControllerParams>();
+                builder.Services.AddControllers()
+                    .AddApplicationPart(typeof(eShopOnlineApiRestful.AssemblyReference).Assembly);
+
+                // NLog: Dependency injection ==> ILogger<T> interface
+                builder.Logging.ClearProviders();   // Clear ALL LogProviders
+                builder.Host.UseNLog();
+
+                // My DIRegister
+                builder.Services.DIRegister_ShopOnlineContext(builder.Configuration);
+                builder.Services.DIRegister_Repositories();
+                builder.Services.DIRegister_Business();
+                //builder.Services.DIRegister_NLog();
+                builder.Services.DIRegister_AutoMapper();
+
+                // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+                builder.Services.AddEndpointsApiExplorer();
+                builder.Services.AddSwaggerGen();
+
+                var app = builder.Build();
+
+                // Configure the HTTP request pipeline.
+                if (app.Environment.IsDevelopment())
+                {
+                    app.UseSwagger();
+                    app.UseSwaggerUI();
+                }
+
+                app.UseHttpsRedirection();
+
+                app.UseAuthorization();
+
+
+                app.MapControllers();
+
+                app.Run();
             }
-
-            app.UseHttpsRedirection();
-
-            app.UseAuthorization();
-
-
-            app.MapControllers();
-
-            app.Run();
+            catch (Exception exception)
+            {
+                // NLog: catch setup errors
+                logger.Error(exception, "Stopped program because of exception");
+                throw;
+            }
+            finally
+            {
+                // Ensure to flush and stop internal timers/threads before application-exit (Avoid segmentation fault on Linux)
+                NLog.LogManager.Shutdown();
+            }
         }
     }
 }

--- a/eShopOnlineApiHost/Properties/launchSettings.json
+++ b/eShopOnlineApiHost/Properties/launchSettings.json
@@ -16,7 +16,7 @@
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7084;http://localhost:5262",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"     //"Production"
       }
     },
     "IIS Express": {
@@ -24,7 +24,7 @@
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development"     //"Production"
       }
     }
   }

--- a/eShopOnlineApiHost/Using.cs
+++ b/eShopOnlineApiHost/Using.cs
@@ -1,0 +1,2 @@
+﻿global using eShopOnlineApiHost.Constants;
+global using eShopOnlineApiHost.Extensions;

--- a/eShopOnlineApiHost/eShopOnlineApiHost.csproj
+++ b/eShopOnlineApiHost/eShopOnlineApiHost.csproj
@@ -7,6 +7,21 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="LogsDev\**" />
+    <Compile Remove="LogsProd\**" />
+    <Compile Remove="Logs\**" />
+    <Content Remove="LogsDev\**" />
+    <Content Remove="LogsProd\**" />
+    <Content Remove="Logs\**" />
+    <EmbeddedResource Remove="LogsDev\**" />
+    <EmbeddedResource Remove="LogsProd\**" />
+    <EmbeddedResource Remove="Logs\**" />
+    <None Remove="LogsDev\**" />
+    <None Remove="LogsProd\**" />
+    <None Remove="Logs\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 


### PR DESCRIPTION
#### =====AFTER=====
**1) Describe the solutions (explain the root causes)**
- In the previous code, I define **an Interface** and **an Implementation** (NLog).
- **`This approach is WRONG`**. Because **Microsoft** already defined an **`ILogger<T>`** interface and used it for the entire code - low layer. It just needs a LogProvider in DI to write this log.
- By default. ASP.NETCore has the **`4 DEFAULT LogProviders`** (`Console`, `Debug`, `EventSource`, `EventLog - only Windows`).
- But none of them can not write the message to file (except NLog).
- I just need to take advantage of **`ILogger<T>`** which is already defined and used.

**2) Pros and Cons of this solution**
- No.

**3) Are there any NEW (technical, code,...) ?**
- Understand ILogger<T> interface.

**4) Is it challenging and difficult to do? Why?**
- It takes time to read the NLog documentation and understand the Config file.

**5) Any other notes?**
- Link Tutorial: [https://github.com/NLog/NLog/wiki/Getting-started-with-ASP.NET-Core-6](url) 